### PR TITLE
chore: fix selene warning on assert arguments

### DIFF
--- a/vim.toml
+++ b/vim.toml
@@ -20,6 +20,8 @@ type = "function"
 [[after_each.args]]
 type = "function"
 
+[assert]
+any = true
 [assert.is_not]
 any = true
 


### PR DESCRIPTION
```sh
❯ ww just check
[Running: just check]
selene ./lua/ ./spec/
error[incorrect_standard_library_use]: standard library function `assert` requires 2 parameters, 1 passed
   ┌─ lua/my-nvim-micro-plugins/main.lua:24:44
   │
24 │     local full_path = vim.fs.joinpath(cwd, assert(selected_file.file))
   │                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^
   │
   = A failed assertion without a message is unhelpful to users.

error[incorrect_standard_library_use]: standard library function `assert` requires 2 parameters, 1 passed
   ┌─ lua/my-nvim-micro-plugins/main.lua:59:25
   │
59 │   local relative_path = assert(result.stdout)
   │                         ^^^^^^^^^^^^^^^^^^^^^
   │
   = A failed assertion without a message is unhelpful to users.
```