### PR TITLE
refactor: use `tui run` instead of `cy:run` in integration tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,7 @@ jobs:
         with:
           install: false
           working-directory: packages/integration-tests
-          command: pnpm cy:run
+          command: pnpm exec tui run
 
       - uses: actions/upload-artifact@v4.6.2
         # add the line below to store screenshots only on failures

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "prettier-plugin-organize-imports": "4.2.0",
     "prettier-plugin-packagejson": "2.5.19"
   },
-  "packageManager": "pnpm@10.12.4+sha512.5ea8b0deed94ed68691c9bad4c955492705c5eeb8a87ef86bc62c74a26b037b08ff9570f108b2e4dbd1dd1a9186fea925e527f141c648e85af45631074680184",
+  "packageManager": "pnpm@10.14.0+sha512.ad27a79641b49c3e481a16a805baa71817a04bbe06a38d17e60e2eaee83f6a146c6a688125f5792e48dd5ba30e7da52a5cda4c3992b9ccf333f9ce223af84748",
   "pnpm": {
     "onlyBuiltDependencies": [
       "core-js",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "dev": "pnpm --filter integration-tests dev",
     "eslint": "pnpm --filter integration-tests eslint",
     "markdownlint": "markdownlint-cli2 README.md",
-    "prettier": "prettier --check ."
+    "prettier": "prettier --check .",
+    "tui": "pnpm --filter ./packages/integration-tests/ exec tui"
   },
   "devDependencies": {
     "@umbrelladocs/linkspector": "0.4.7",

--- a/packages/integration-tests/MyTestDirectory.ts
+++ b/packages/integration-tests/MyTestDirectory.ts
@@ -8,7 +8,7 @@
 // be written with confidence that the files and directories they expect are
 // actually found. Otherwise the tests are brittle and can break easily.
 
-import { z } from "zod"
+import * as z from "zod"
 
 export const MyTestDirectorySchema = z.object({
   name: z.literal("test-environment/"),

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -15,7 +15,7 @@
     "@catppuccin/palette": "1.7.1"
   },
   "devDependencies": {
-    "@tui-sandbox/library": "11.4.1",
+    "@tui-sandbox/library": "11.6.0",
     "concurrently": "9.2.0",
     "cypress": "14.5.3",
     "eslint": "9.32.0",
@@ -26,6 +26,6 @@
     "typescript": "5.9.2",
     "typescript-eslint": "8.39.0",
     "wait-on": "8.0.4",
-    "zod": "4.0.14"
+    "zod": "4.0.15"
   }
 }

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "build": "tsc && vite build",
     "cy:open": "cypress open --e2e --browser=electron",
-    "cy:run": "concurrently --success command-cypress --kill-others --names 'app,cypress' --prefix-colors 'blue,yellow' 'pnpm tui start' 'wait-on --timeout 60000 http://127.0.0.1:3000 && npx cypress run'",
     "dev": "concurrently --kill-others --names 'app,cypress' --prefix-colors 'blue,yellow' 'pnpm tui start' 'pnpm cy:open'",
     "dev:client": "vite",
     "eslint": "eslint --max-warnings=0 ."

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,8 +31,8 @@ importers:
         version: 1.7.1
     devDependencies:
       '@tui-sandbox/library':
-        specifier: 11.4.1
-        version: 11.4.1(cypress@14.5.3)(prettier@3.6.2)(type-fest@4.41.0)(typescript@5.9.2)(zod@4.0.14)
+        specifier: 11.6.0
+        version: 11.6.0(cypress@14.5.3)(prettier@3.6.2)(type-fest@4.41.0)(typescript@5.9.2)(zod@4.0.15)
       concurrently:
         specifier: 9.2.0
         version: 9.2.0
@@ -64,8 +64,8 @@ importers:
         specifier: 8.0.4
         version: 8.0.4
       zod:
-        specifier: 4.0.14
-        version: 4.0.14
+        specifier: 4.0.15
+        version: 4.0.15
 
 packages:
 
@@ -361,19 +361,19 @@ packages:
   '@tootallnate/quickjs-emscripten@0.23.0':
     resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
 
-  '@trpc/client@11.4.3':
-    resolution: {integrity: sha512-i2suttUCfColktXT8bqex5kHW5jpT15nwUh0hGSDiW1keN621kSUQKcLJ095blqQAUgB+lsmgSqSMmB4L9shQQ==}
+  '@trpc/client@11.4.4':
+    resolution: {integrity: sha512-86OZl+Y+Xlt9ITGlhCMImERcsWCOrVzpNuzg3XBlsDSmSs9NGsghKjeCpJQlE36XaG3aze+o9pRukiYYvBqxgQ==}
     peerDependencies:
-      '@trpc/server': 11.4.3
+      '@trpc/server': 11.4.4
       typescript: '>=5.7.2'
 
-  '@trpc/server@11.4.3':
-    resolution: {integrity: sha512-wnWq3wiLlMOlYkaIZz+qbuYA5udPTLS4GVVRyFkr6aT83xpdCHyVtURT+u4hSoIrOXQM9OPCNXSXsAujWZDdaw==}
+  '@trpc/server@11.4.4':
+    resolution: {integrity: sha512-VkJb2xnb4rCynuwlCvgPBh5aM+Dco6fBBIo6lWAdJJRYVwtyE5bxNZBgUvRRz/cFSEAy0vmzLxF7aABDJfK5Rg==}
     peerDependencies:
       typescript: '>=5.7.2'
 
-  '@tui-sandbox/library@11.4.1':
-    resolution: {integrity: sha512-Ip2ozHXfniaZF/M/y3kqBDeKujNQywqA3TjvyXyHCdgdR1NsR/gFad0LDhmTZ1J5c7WhjNg7NiyVRIu4rOmypw==}
+  '@tui-sandbox/library@11.6.0':
+    resolution: {integrity: sha512-H6nmttFsDIJZzfFFjSGnf6VLRRGShGOSSD+un1tOYsEt2b/yT7rf2YxsYnVHau53FamwOY0eFQlUTwb/KSsSOQ==}
     engines: {node: '>=24.0.0'}
     hasBin: true
     peerDependencies:
@@ -2478,8 +2478,8 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
-  zod@4.0.14:
-    resolution: {integrity: sha512-nGFJTnJN6cM2v9kXL+SOBq3AtjQby3Mv5ySGFof5UGRHrRioSJ5iG680cYNjE/yWk671nROcpPj4hAS8nyLhSw==}
+  zod@4.0.15:
+    resolution: {integrity: sha512-2IVHb9h4Mt6+UXkyMs0XbfICUh1eUrlJJAOupBHUhLRnKkruawyDddYRCs0Eizt900ntIMk9/4RksYl+FgSpcQ==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -2726,23 +2726,24 @@ snapshots:
 
   '@tootallnate/quickjs-emscripten@0.23.0': {}
 
-  '@trpc/client@11.4.3(@trpc/server@11.4.3(typescript@5.9.2))(typescript@5.9.2)':
+  '@trpc/client@11.4.4(@trpc/server@11.4.4(typescript@5.9.2))(typescript@5.9.2)':
     dependencies:
-      '@trpc/server': 11.4.3(typescript@5.9.2)
+      '@trpc/server': 11.4.4(typescript@5.9.2)
       typescript: 5.9.2
 
-  '@trpc/server@11.4.3(typescript@5.9.2)':
+  '@trpc/server@11.4.4(typescript@5.9.2)':
     dependencies:
       typescript: 5.9.2
 
-  '@tui-sandbox/library@11.4.1(cypress@14.5.3)(prettier@3.6.2)(type-fest@4.41.0)(typescript@5.9.2)(zod@4.0.14)':
+  '@tui-sandbox/library@11.6.0(cypress@14.5.3)(prettier@3.6.2)(type-fest@4.41.0)(typescript@5.9.2)(zod@4.0.15)':
     dependencies:
       '@catppuccin/palette': 1.7.1
-      '@trpc/client': 11.4.3(@trpc/server@11.4.3(typescript@5.9.2))(typescript@5.9.2)
-      '@trpc/server': 11.4.3(typescript@5.9.2)
+      '@trpc/client': 11.4.4(@trpc/server@11.4.4(typescript@5.9.2))(typescript@5.9.2)
+      '@trpc/server': 11.4.4(typescript@5.9.2)
       '@xterm/addon-fit': 0.10.0(@xterm/xterm@5.5.0)
       '@xterm/addon-unicode11': 0.8.0(@xterm/xterm@5.5.0)
       '@xterm/xterm': 5.5.0
+      concurrently: 9.2.0
       cors: 2.8.5
       cypress: 14.5.3
       dree: 5.1.5
@@ -2753,7 +2754,7 @@ snapshots:
       type-fest: 4.41.0
       typescript: 5.9.2
       winston: 3.17.0
-      zod: 4.0.14
+      zod: 4.0.15
     transitivePeerDependencies:
       - supports-color
 
@@ -5220,6 +5221,6 @@ snapshots:
 
   zod@3.25.76: {}
 
-  zod@4.0.14: {}
+  zod@4.0.15: {}
 
   zwitch@2.0.4: {}


### PR DESCRIPTION
# refactor: use `tui run` instead of `cy:run` in integration tests

# chore: bump pnpm from 10.12.4 to 10.14.0

