### PR TITLE
ci: no need to install yq as it comes preinstalled

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,8 +42,6 @@ jobs:
               https://raw.githubusercontent.com/houseabsolute/ubi/master/bootstrap/bootstrap-ubi.sh |
               TARGET="$HOME/.local/bin" sh
 
-          ubi --project mikefarah/yq
-
           # fd is used for searching files
           VERSION=$(yq '.tools."github:sharkdp/fd"' mise.toml)
           ubi --project sharkdp/fd --tag "v$VERSION"


### PR DESCRIPTION
# ci: no need to install yq as it comes preinstalled

https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md already contains `yq 4.53.3`

---

# Pull request stack

- 👉🏻 **[#758](https://github.com/mikavilpas/my-nvim-micro-plugins.nvim/pull/758)** | ci: no need to install yq as it comes preinstalled 👈🏻