### PR TITLE
ci: split busted tests into a separate job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,3 +115,25 @@ jobs:
           name: cypress-screenshots
           path: packages/integration-tests/cypress/screenshots
           if-no-files-found: ignore # 'warn' or 'error' are also available, defaults to `warn`
+
+  ci:
+    name: ci
+    if: ${{ always() }}
+    needs:
+      - build-neovim-nightly
+      - busted
+      - build
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Verify all required jobs succeeded
+        if: >-
+          ${{
+            contains(needs.*.result, 'failure')
+            || contains(needs.*.result, 'cancelled')
+            || contains(needs.*.result, 'skipped')
+          }}
+        run: |
+          echo "One or more required jobs did not succeed."
+          exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,23 @@ jobs:
         with:
           commit: ${{ env.NEOVIM_NIGHTLY_COMMIT }}
 
+  busted:
+    name: "Busted"
+    runs-on: ubuntu-24.04
+    needs: build-neovim-nightly
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Download pinned Neovim nightly
+        uses: mikavilpas/neovim-action/restore-nightly@4f1c9a2235ee7428930602c0ba3e4f20377b61d8 # v3.3.0
+        with:
+          commit: ${{ env.NEOVIM_NIGHTLY_COMMIT }}
+
+      - name: Run tests
+        uses: mikavilpas/neovim-action/busted@4f1c9a2235ee7428930602c0ba3e4f20377b61d8 # v3.3.0
+
   build:
     name: Run tests
     needs: build-neovim-nightly
@@ -65,9 +82,6 @@ jobs:
         uses: mikavilpas/neovim-action/restore-nightly@4f1c9a2235ee7428930602c0ba3e4f20377b61d8 # v3.3.0
         with:
           commit: ${{ env.NEOVIM_NIGHTLY_COMMIT }}
-
-      - name: Run tests
-        uses: mikavilpas/neovim-action/busted@4f1c9a2235ee7428930602c0ba3e4f20377b61d8 # v3.3.0
 
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:


### PR DESCRIPTION
# ci: add success gate for easy required check maintenance

# ci: split busted tests into a separate job

---

# Pull request stack

- 👉🏻 **[#759](https://github.com/mikavilpas/my-nvim-micro-plugins.nvim/pull/759)** | ci: split busted tests into a separate job 👈🏻